### PR TITLE
Fix query no errors

### DIFF
--- a/server/data/queries.go
+++ b/server/data/queries.go
@@ -23,7 +23,7 @@ func (str *Store) QueryAssetById(id int) (Asset, error) {
 		return err
 	})
 
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil {
 		return Asset{}, err
 	}
 
@@ -43,7 +43,7 @@ func (str *Store) QueryContractById(id int) (Contract, error) {
 		return err
 	})
 
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil {
 		return Contract{}, err
 	}
 
@@ -63,7 +63,7 @@ func (str *Store) QueryUserById(id int) (User, error) {
 		return err
 	})
 
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil {
 		return User{}, err
 	}
 
@@ -83,7 +83,7 @@ func (str *Store) QueryContribById(id int) (Contribution, error) {
 		return err
 	})
 
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil {
 		return Contribution{}, err
 	}
 

--- a/server/data/queries_test.go
+++ b/server/data/queries_test.go
@@ -27,6 +27,11 @@ func TestQueryAssetByID(t *testing.T) {
 		_, err := str.QueryAssetById(i)
 		require.NoError(t, err)
 	}
+
+  // Should show error if AssetID doesnt exist
+  asset, err := str.QueryAssetById(1000)
+  require.Error(t, err)
+  require.Equal(t, asset.AssetID, 0)
 }
 
 func TestQueryContractByID(t *testing.T) {
@@ -37,6 +42,11 @@ func TestQueryContractByID(t *testing.T) {
 		_, err := str.QueryContractById(i)
 		require.NoError(t, err)
 	}
+
+  // Should show error if ContractID doesnt exist
+  contract, err := str.QueryContractById(1000)
+  require.Error(t, err)
+  require.Equal(t, contract.ContractID, 0)
 }
 
 func TestQueryUserByID(t *testing.T) {
@@ -47,6 +57,11 @@ func TestQueryUserByID(t *testing.T) {
 		_, err := str.QueryUserById(i)
 		require.NoError(t, err)
 	}
+
+  // Should show error if UserID doesnt exist
+  user, err := str.QueryUserById(1000)
+  require.Error(t, err)
+  require.Equal(t, user.UserID, 0)
 }
 
 func TestQueryContribByID(t *testing.T) {
@@ -57,6 +72,11 @@ func TestQueryContribByID(t *testing.T) {
 		_, err := str.QueryContribById(i)
 		require.NoError(t, err)
 	}
+
+  // Should show error if ContribID doesnt exist
+  contrib, err := str.QueryContribById(1000)
+  require.Error(t, err)
+  require.Equal(t, contrib.ContribID, 0)
 }
 
 func TestInsertAsset(t *testing.T) {


### PR DESCRIPTION
Fixed an issue where querying for a database object by it's ID wouldn't return an error if the object didn't exist. Tests were added to make sure the issue is automatically caught in the future. 