### PR TITLE
Feat: implementation of profile creation component

### DIFF
--- a/server/routes/api.go
+++ b/server/routes/api.go
@@ -50,8 +50,10 @@ func (api API) Start(port string, seed bool) {
 func (api API) get(route string, handler routeHandler) {
 	api.Router.GET(route, func(c *gin.Context) {
 		// Enable CORS
-		c.Header("Access-Control-Allow-Origin", "*")
+    c.Header("Access-Control-Allow-Origin", "*")
 		c.Header("Access-Control-Allow-Methods", "PUT, POST, GET, DELETE, OPTIONS")
+    c.Header("Access-Control-Allow-Headers", "X-Requested-With, content-type")
+    c.Header("Access-Control-Allow-Credentials", "true")
 
 		// Pass JWT secret
 		c.Set("jwt-secret", api.secret)
@@ -65,6 +67,8 @@ func (api API) post(route string, handler routeHandler) {
 		// Enable CORS
 		c.Header("Access-Control-Allow-Origin", "*")
 		c.Header("Access-Control-Allow-Methods", "PUT, POST, GET, DELETE, OPTIONS")
+    c.Header("Access-Control-Allow-Headers", "X-Requested-With, content-type")
+    c.Header("Access-Control-Allow-Credentials", "true")
 
 		// Pass JWT secret
 		c.Set("jwt-secret", api.secret)

--- a/src/app/account.service.spec.ts
+++ b/src/app/account.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AccountService } from './account.service';
+
+describe('AccountService', () => {
+  let service: AccountService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AccountService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/account.service.ts
+++ b/src/app/account.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { Observable } from 'rxjs';
+import  Web3  from 'web3';
+
+declare let window: any;
+let web3: Web3;
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AccountService {
+  web3: any
+  userHasAccount = false
+
+  constructor() { }
+
+  public hasAccount = new BehaviorSubject<boolean>(false);
+  nonce: any;
+  userAddress: any;
+  walletId: any;
+
+  get hasAccount$(): Observable<boolean> {
+    return this.hasAccount.asObservable();
+  }
+
+  public async checkProfileExists() {
+    const web3 = new Web3(window.ethereum);
+    await window.ethereum.request({ method: 'eth_requestAccounts' });
+    const account = await web3.eth.getAccounts();
+    this.userAddress = account[0];
+    this.nonce = await web3.eth.getTransactionCount(this.userAddress);
+    this.walletId = web3.utils.soliditySha3(this.userAddress, this.nonce);
+    try {
+      fetch('http://localhost:8080/api/users/${walletId}', {
+        method: 'GET'
+      })
+        .then(res => res.json())
+        .then(data => {
+          console.log(data)
+          if (data[0] == this.walletId) {
+            this.userHasAccount = true;
+          }
+          else{
+            this.userHasAccount = false;
+          }
+        })
+      const accounts = await window.ethereum.request({ method: 'eth_accounts' });
+      this.hasAccount.next(this.userHasAccount);
+    } catch (error) {
+      console.log(error);
+    }
+      this.hasAccount.next(true);
+  }
+}
+

--- a/src/app/account.service.ts
+++ b/src/app/account.service.ts
@@ -50,7 +50,6 @@ export class AccountService {
     } catch (error) {
       console.log(error);
     }
-      this.hasAccount.next(true);
   }
 }
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -8,9 +8,9 @@
         <span class="search-icon" ><i class="fa-solid fa-magnifying-glass"></i></span>
     </div>
 
-    <div class="connect-wallet-btn" routerLink = "connect-wallet" >
+    <div class="connect-wallet-btn" [routerLink] = "profileLink" >
         <div>
-            Connect
+            {{buttonText}}
         </div>
         <div>
         <svg fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M64 32C28.7 32 0 60.7 0 96V416c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V192c0-35.3-28.7-64-64-64H80c-8.8 0-16-7.2-16-16s7.2-16 16-16H448c17.7 0 32-14.3 32-32s-14.3-32-32-32H64zM416 272a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"/></svg>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { AccountService } from './account.service';
 
 @Component({
   selector: 'app-root',
@@ -8,13 +9,31 @@ import { Component } from '@angular/core';
 export class AppComponent {
   title = 'CrowdNFT';
   displayWelcomeMessage: boolean;
+  profileLink = 'connect-wallet';
+  buttonText = 'Connect';
 
-  constructor(){
+  constructor(private accountService: AccountService) {
     this.displayWelcomeMessage = true;
-  };
+  }
+
+  ngOnInit() {
+    this.accountService.hasAccount$.subscribe(hasAccount => {
+      if (hasAccount) {
+        this.profileLink = 'profile';
+        this.buttonText = 'View Profile';
+      }
+      else{
+        this.profileLink = 'connect-wallet';
+        this.buttonText = 'Connect'
+      }
+    });
+  }
+
+  
 
   public closeWelcomeMessage(){
     this.displayWelcomeMessage = false;
   }
+
 }
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -7,20 +7,28 @@ import { AppComponent } from './app.component';
 import { HomeComponent } from './home/home.component';
 import { NftCardComponent } from './nft-card/nft-card.component';
 import { ConnectWalletComponent } from './connect-wallet/connect-wallet.component';
+import { ProfileCreationComponent } from './profile-creation/profile-creation.component';
+import { FormsModule } from '@angular/forms';
+import { HttpClientModule } from '@angular/common/http';
+
 
 const routes: Routes = [ {path: '', component: HomeComponent}, 
-  { path: 'connect-wallet', component: ConnectWalletComponent }];
+  { path: 'connect-wallet', component: ConnectWalletComponent },
+{ path: 'profile-creation', component: ProfileCreationComponent}];
 
 @NgModule({
   declarations: [
     AppComponent,
     HomeComponent,
     NftCardComponent,
-    ConnectWalletComponent
+    ConnectWalletComponent,
+    ProfileCreationComponent
   ],
   imports: [
     BrowserModule,
     AppRoutingModule,
+    HttpClientModule,
+    FormsModule,
     RouterModule,
     [RouterModule.forRoot(routes)]
   ],

--- a/src/app/connect-wallet/connect-wallet.component.ts
+++ b/src/app/connect-wallet/connect-wallet.component.ts
@@ -1,4 +1,6 @@
+import { AccountService } from './../account.service';
 import { Component } from '@angular/core';
+import { Router } from '@angular/router';
 import Web3 from 'web3';
 
 declare let window: any;
@@ -13,7 +15,10 @@ let web3: Web3;
 
 export class ConnectWalletComponent {
   web3: any
+  buttonText = 'Connect'
   public metaMaskInstalled: boolean = false;
+
+  constructor(private accountService: AccountService, private router: Router) { }
 
   public async login() {
     if (typeof window.ethereum !== 'undefined') {
@@ -25,6 +30,17 @@ export class ConnectWalletComponent {
     } catch (error) {
       console.error(error);
     }
+    this.accountService.checkProfileExists();
+    this.accountService.hasAccount$.subscribe(hasAccount => {
+      if (!hasAccount) {
+        this.router.navigate(['profile-creation']);
+        this.buttonText = 'Connect';
+      }
+      else{
+        this.buttonText = 'View Profile';
+        this.router.navigate(['']);
+      }
+    });
   }
   else{
     console.log("User does not have Meta Mask extension");

--- a/src/app/profile-creation/profile-creation.component.css
+++ b/src/app/profile-creation/profile-creation.component.css
@@ -1,0 +1,35 @@
+button {
+    margin-left: 12px;
+    border-radius: 8px;
+    padding: 12px 24px;
+    border: 2px solid rgb(212,73,134);
+    background: white;
+    transition: all 0.2s ease-in-out;
+    color: rgb(212,73,134);
+    font-size: 1.2rem;
+    }
+
+button:hover {
+    cursor: pointer;
+    background: rgb(212,73,134);
+    color: white;
+    }
+
+.input {
+    width: 100%;
+}
+
+ form {
+    background-color: #fafafa;
+    margin: 24px;
+    padding: 24px;
+    height: 200 vw;
+    box-shadow: rgba(0, 0, 0, 0.3) 0px 19px 38px, rgba(0, 0, 0, 0.22) 0px 15px 12px;
+    border-radius: 12px;
+    color: rgba(5, 5, 5, 0.657);
+    width: 75vw;
+    position: absolute;
+    top: calc(50vh - 60px);
+    left: 50vw;
+    transform: translate(-50%, -50%);
+    }

--- a/src/app/profile-creation/profile-creation.component.html
+++ b/src/app/profile-creation/profile-creation.component.html
@@ -2,7 +2,7 @@
 <form (ngSubmit)="onSubmit()" class ="form">
     <label>
       Share a profile picture:
-      <input type="url" name="profilePic" class = "input" placeholder = "Enter a picture url here!" [(ngModel)]="Account.profilePicUrl">
+      <input type="url" name="profile_pic_url" class = "input" placeholder = "Enter a picture url here!" [(ngModel)]="Account.profile_pic_url">
     </label>
     <br>
     <label>

--- a/src/app/profile-creation/profile-creation.component.html
+++ b/src/app/profile-creation/profile-creation.component.html
@@ -1,0 +1,14 @@
+
+<form (ngSubmit)="onSubmit()" class ="form">
+    <label>
+      Share a profile picture:
+      <input type="url" name="profilePic" class = "input" placeholder = "Enter a picture url here!" [(ngModel)]="Account.profilePicUrl">
+    </label>
+    <br>
+    <label>
+      Enter a bio:
+      <input type="text" name="bio" class = "input" placeholder = "Enter a bio here!" [(ngModel)]="Account.bio">
+    </label>
+    <br>
+    <button type="submit" class ="button">Submit</button>
+  </form>

--- a/src/app/profile-creation/profile-creation.component.spec.ts
+++ b/src/app/profile-creation/profile-creation.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProfileCreationComponent } from './profile-creation.component';
+
+describe('ProfileCreationComponent', () => {
+  let component: ProfileCreationComponent;
+  let fixture: ComponentFixture<ProfileCreationComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ProfileCreationComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ProfileCreationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/profile-creation/profile-creation.component.ts
+++ b/src/app/profile-creation/profile-creation.component.ts
@@ -1,0 +1,45 @@
+import { Router } from '@angular/router';
+import { Component } from '@angular/core';
+import { AccountService } from '../account.service';
+import {HttpClient} from '@angular/common/http'
+
+@Component({
+  selector: 'app-profile-creation',
+  templateUrl: './profile-creation.component.html',
+  styleUrls: ['./profile-creation.component.css']
+})
+export class ProfileCreationComponent {
+  Account = {
+    userId: '',
+    addr: '',
+    nonce: '',
+    profilePicUrl: '',
+    bio: ''
+  }
+
+  constructor(private accountService: AccountService, private http: HttpClient, private router:Router){
+  }
+
+  onSubmit(){
+    this.Account.userId = this.accountService.walletId;
+    this.Account.addr = this.accountService.userAddress;
+    this.Account.nonce = this.accountService.nonce;
+    const accountInfo = {
+        profilePic: this.Account.profilePicUrl,
+        bio: this.Account.bio
+    }
+    if(this.Account.profilePicUrl == ''){
+      this.Account.profilePicUrl = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBwgHBgkIBwgKCgkLDRYPDQwMDRsUFRAWIB0iIiAdHx8kKDQsJCYxJx8fLT0tMTU3Ojo6Iys/RD84QzQ5OjcBCgoKDQwNGg8PGjclHyU3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3N//AABEIAIEAgQMBIgACEQEDEQH/xAAbAAEAAgMBAQAAAAAAAAAAAAAAAwUBBAYCB//EADIQAQABAwEDBw0BAQAAAAAAAAABAgMEEQUSITEyNEFRcbEVIiNCUlNhYnJzkqHhwRP/xAAWAQEBAQAAAAAAAAAAAAAAAAAAAQL/xAAWEQEBAQAAAAAAAAAAAAAAAAAAEQH/2gAMAwEAAhEDEQA/APogDbIAAAAAAAAAAAAAAM6AMAAAAAACfGxL+TPo6Y3fankb1GxtY8+9GvywVVULS5saqI9HeiZ7JhX3rF2xVu3aJp7J6pSiMBUAAAAAAAAAAGzg4s5V7cnmRxq7mtK82Jb3MWa5jjXP6TVb1FFNFMU0xpERpEQ9MsMqIsmzTftVW644TyfBKyDlr1qqzcqt186JRrTblqIu27sRzo0mVW1moAKgAAAAAAABLotl9Btd0+LnV3sW7FWPNvXjRPJ8JTVWQDKgEgq9ux6C39f+KZZbdu71yi3E82NZVsNYgEioAAAAAAAAJ8PInGvxcjjHJVHbCANV1Vqum5RFdE60zyPbmcXLvYusW5jd9meRYW9tU7sf9LNW98ssxVsgzMmjGs1V1cvqx2yrru2ZmNLNrSe2tXZGRcyLm/dq1nq+BEebtdV27VcqnWap1eQaQAAAAAAAAGY4zpHKt9n7NimIuZFMTV1Uz1G6qvx8PIyONFGlPtTwhu0bGq08+9Ed1K35GWaqp8ix7+fxY8ix7+fx/q3EoqPIse/n8f6eRY9/P4/1bi0Ulex70cy7RV3xMNO/iZFiJm5aqiO2OMOnYmNSpHJi32hs2JibuNTpPrUR19yoaAAQAAA5eECrLY2Nv3Jv1x5tPCnXtXaLGtRYsUW49WP2lYUAAAAAAAAUO1saLF+LlEeZc/Ur5pbXo3sGueumYqXBz4QNMgACTHjeyLVPbXEftGmxOl2fuU+IOnAYaAAAAAAAAGvtDoN/6JbCHNjXEvR8k+AOYAbQAEE2J0qz9ynxAHTgMNAAAAAAAACLJ6Nd+ifAAcvADaAAj//Z';
+    }
+
+    if(this.Account.bio == ''){
+      this.Account.bio = 'This is my bio!';
+    }
+
+    this.http.post("http://localhost:8080/api/users/", this.Account).subscribe(response => {
+      console.log(response);
+    });
+    this.accountService.hasAccount.next(true);
+    this.router.navigate(['']);
+  }
+}

--- a/src/app/profile-creation/profile-creation.component.ts
+++ b/src/app/profile-creation/profile-creation.component.ts
@@ -1,45 +1,60 @@
 import { Router } from '@angular/router';
 import { Component } from '@angular/core';
 import { AccountService } from '../account.service';
-import {HttpClient} from '@angular/common/http'
+import { HttpClient } from '@angular/common/http'
 
 @Component({
   selector: 'app-profile-creation',
   templateUrl: './profile-creation.component.html',
   styleUrls: ['./profile-creation.component.css']
 })
+
 export class ProfileCreationComponent {
   Account = {
-    userId: '',
-    addr: '',
-    nonce: '',
-    profilePicUrl: '',
-    bio: ''
+    profile_pic_url: '',
+    bio: '',
   }
 
   constructor(private accountService: AccountService, private http: HttpClient, private router:Router){
   }
 
-  onSubmit(){
-    this.Account.userId = this.accountService.walletId;
-    this.Account.addr = this.accountService.userAddress;
-    this.Account.nonce = this.accountService.nonce;
-    const accountInfo = {
-        profilePic: this.Account.profilePicUrl,
-        bio: this.Account.bio
-    }
-    if(this.Account.profilePicUrl == ''){
-      this.Account.profilePicUrl = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBwgHBgkIBwgKCgkLDRYPDQwMDRsUFRAWIB0iIiAdHx8kKDQsJCYxJx8fLT0tMTU3Ojo6Iys/RD84QzQ5OjcBCgoKDQwNGg8PGjclHyU3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3N//AABEIAIEAgQMBIgACEQEDEQH/xAAbAAEAAgMBAQAAAAAAAAAAAAAAAwUBBAYCB//EADIQAQABAwEDBw0BAQAAAAAAAAABAgMEEQUSITEyNEFRcbEVIiNCUlNhYnJzkqHhwRP/xAAWAQEBAQAAAAAAAAAAAAAAAAAAAQL/xAAWEQEBAQAAAAAAAAAAAAAAAAAAEQH/2gAMAwEAAhEDEQA/APogDbIAAAAAAAAAAAAAAM6AMAAAAAACfGxL+TPo6Y3fankb1GxtY8+9GvywVVULS5saqI9HeiZ7JhX3rF2xVu3aJp7J6pSiMBUAAAAAAAAAAGzg4s5V7cnmRxq7mtK82Jb3MWa5jjXP6TVb1FFNFMU0xpERpEQ9MsMqIsmzTftVW644TyfBKyDlr1qqzcqt186JRrTblqIu27sRzo0mVW1moAKgAAAAAAABLotl9Btd0+LnV3sW7FWPNvXjRPJ8JTVWQDKgEgq9ux6C39f+KZZbdu71yi3E82NZVsNYgEioAAAAAAAAJ8PInGvxcjjHJVHbCANV1Vqum5RFdE60zyPbmcXLvYusW5jd9meRYW9tU7sf9LNW98ssxVsgzMmjGs1V1cvqx2yrru2ZmNLNrSe2tXZGRcyLm/dq1nq+BEebtdV27VcqnWap1eQaQAAAAAAAAGY4zpHKt9n7NimIuZFMTV1Uz1G6qvx8PIyONFGlPtTwhu0bGq08+9Ed1K35GWaqp8ix7+fxY8ix7+fx/q3EoqPIse/n8f6eRY9/P4/1bi0Ulex70cy7RV3xMNO/iZFiJm5aqiO2OMOnYmNSpHJi32hs2JibuNTpPrUR19yoaAAQAAA5eECrLY2Nv3Jv1x5tPCnXtXaLGtRYsUW49WP2lYUAAAAAAAAUO1saLF+LlEeZc/Ur5pbXo3sGueumYqXBz4QNMgACTHjeyLVPbXEftGmxOl2fuU+IOnAYaAAAAAAAAGvtDoN/6JbCHNjXEvR8k+AOYAbQAEE2J0qz9ynxAHTgMNAAAAAAAACLJ6Nd+ifAAcvADaAAj//Z';
-    }
+  async onSubmit(){
+    const addr = await this.accountService.address();
 
-    if(this.Account.bio == ''){
+    if(this.Account.profile_pic_url == '')
+      this.Account.profile_pic_url = 'https://i.seadn.io/gae/AL_lAfiHmqpFk72vHLLTEO8zuRWWYsqRH2uiCld3UuCo8ZAqTah5PwwhtmfFYvlGlTmLh9M7blNUK8kUqzXGN-Lk4hRtUPqAVL9W?auto=format&w=1000';
+
+    if(this.Account.bio == '')
       this.Account.bio = 'This is my bio!';
+
+    // Get signature
+    const sig = await this.accountService.signMessage(`ADDR:${addr}`)
+    if (sig == '') {
+      this.router.navigate([''])
+      alert("Invalid signature")
     }
 
-    this.http.post("http://localhost:8080/api/users/", this.Account).subscribe(response => {
-      console.log(response);
-    });
-    this.accountService.hasAccount.next(true);
-    this.router.navigate(['']);
+    // Signup
+    const xhttp = new XMLHttpRequest();
+    xhttp.onreadystatechange = () => {
+      if (xhttp.readyState === 4) {
+        if (xhttp.status !== 200) {
+          alert(JSON.parse(xhttp.responseText).error)
+          return
+        }
+
+        alert("Succesfully signed up")
+        this.accountService.hasAccount.next(true);
+        this.router.navigate(['']);
+      }
+    }
+
+    xhttp.open('POST', 'http://localhost:8080/api/auth/signup');
+    xhttp.send(JSON.stringify({
+      addr: addr,
+      profile_pic_url: this.Account.profile_pic_url,
+      bio: this.Account.bio,
+      sig: sig
+    }));
   }
 }


### PR DESCRIPTION
This code creates the profile creation component which facilitates any user that wishes to make an account using their wallet id.  The code in account service extracts the nonce and user address to find the users walletID which is then used to query the API to see if the user has an account.
![image](https://user-images.githubusercontent.com/44647363/228423473-ac0410f4-e457-485d-9b2b-a4d157dc6141.png)
If they don't have an account they are navigated to the profile creation page where they will submit a profile picture and a bio if they would like.  If they don't enter values a default bio and picture url will be given to their account.  This data is then inputted into an account object which will then be posted to the API.
![image](https://user-images.githubusercontent.com/44647363/228423709-8f998ac8-f3d8-4e6e-af34-763ba6d17455.png)
Other small changes involved in this commit come from the app component.  All the change is if the hasAccount variable in the account service is true then the connect wallet button becomes a view profile button.
![image](https://user-images.githubusercontent.com/44647363/228423850-480d5bd8-a27a-4f63-b218-9d69f9cafcc0.png)
